### PR TITLE
use the model name instead of file name as the hash key

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ models.User
 models.Contacts.Contact
 ```
 
+Note: The model name is how it will be exposed, e.g: ```javascript var User = sequelize.define('User', {}, {}); ``` will be exposed as ```javascript models.User```.
+
 Note that ``sequelize-import`` will recursively search for ``js`` files inside specified directory.
 
 With this you can separate models definitions into multiple files, and then load it into some central place, then define relations between models, etc.

--- a/index.js
+++ b/index.js
@@ -43,7 +43,8 @@ function load(PATH, sequelize, opts) {
       models[file] = load(path.join(PATH, file), sequelize, opts);
     } else {
       file = file.split('.')[0];
-      models[file] = sequelize.import(path.join(PATH, file));
+      var model = sequelize.import(path.join(PATH, file))
+      models[model.name] = model;
     }
   });
   return models;

--- a/test/index.js
+++ b/test/index.js
@@ -16,7 +16,7 @@ describe('Connection', function () {
   describe('importing models', function () {
     it('should import models', function () {
       models = sequelizeImport(path.join(__dirname, 'models'), sequelize);
-      Object.keys(models).length.should.be.exactly(2);
+      Object.keys(models).length.should.be.exactly(3);
     });
 
     it('should have User property', function () {
@@ -29,6 +29,11 @@ describe('Connection', function () {
 
     it('should have contact property', function () {
       models.Contacts.should.have.property('Contact');
+    });
+
+    it('uses the model name supplied by sequelize', function(){
+      models.should.have.property('Post')
+      models.should.not.have.property('post');
     });
   });
 });

--- a/test/models/post.js
+++ b/test/models/post.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = function (sequelize, DataTypes) {
+	return sequelize.define('Post', {
+		title: DataTypes.STRING,
+		body: DataTypes.STRING
+	});
+};


### PR DESCRIPTION
This seems to be closer to how sequelize do things in their own documentation.

e.g.

``` javascript
fs.readdirSync(__dirname)
  .filter(function(file) {                                    
    return (file.indexOf('.') !== 0) && (file !== 'index.js') 
  })                                                          
  .forEach(function(file) {                                   
    var model = sequelize.import(path.join(__dirname, file))  
    db[model.name] = model
  });

```
