### PR TITLE
Adding associate method call in import

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,13 @@ function load(PATH, sequelize, opts) {
       models[model.name] = model;
     }
   });
+
+  Object.keys(models).forEach((modelName) => {
+    if ('associate' in models[modelName]) {
+      models[modelName].associate(models)
+    }
+  })
+
   return models;
 }
 


### PR DESCRIPTION
For relations in models it is necesary to invocate the associate method of each model and send it an object with all models, like next:
`const db = {
  Person: sequelize.import(__dirname + '/models/persona'),
  User: sequelize.import(__dirname + '/models/user')
}
Object.keys(db).forEach((modelName) => {
  if ('associate' in db[modelName]) {
    db[modelName].associate(db)
  }
})`
this code is now in a sequelize-import, and when you use it, it is not necesary to include the code above. Simplitly doing this(the below code), , all models ans his relationships are included.
`var models = require('sequelize-import')(__dirname + '/models', sequelize, { 
	exclude: ['index.js']
})`